### PR TITLE
[Feat/md-editor] 마크다운 에디터/뷰어 기능 실험추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@uiw/react-md-editor": "^4.0.8",
+        "lucide-react": "^0.525.0",
         "next": "15.4.3",
         "postcss": "^8.5.6",
         "react": "19.1.0",
@@ -5145,6 +5146,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@uiw/react-md-editor": "^4.0.8",
+    "lucide-react": "^0.525.0",
     "next": "15.4.3",
     "postcss": "^8.5.6",
     "react": "19.1.0",

--- a/src/app/MDTest/page.js
+++ b/src/app/MDTest/page.js
@@ -1,0 +1,18 @@
+import Image from "next/image";
+import MDEdit from "@/components/posts/MDEdit";
+
+export default function Home() {
+  return (
+    <div className="flex flex-col h-screen">
+      {/* 고정 헤더 */}
+      <header className="h-16 bg-blue-600 text-white flex items-center justify-center shadow-md z-10">
+        <h1 className="text-xl font-bold">더미 헤더</h1>
+      </header>
+
+      {/* 스크롤 가능한 콘텐츠 영역 */}
+      <main className="flex-1 overflow-y-auto bg-gray-100 p-4">
+        <MDEdit height="500"/>
+      </main>
+    </div>
+  );
+}

--- a/src/app/MDTest/page.js
+++ b/src/app/MDTest/page.js
@@ -1,18 +1,26 @@
-import Image from "next/image";
+"use client"
+
+// MD 에디터에서 값 받아오는 방법.
+// 1. useRef 임포트
+// 2. useRef를 사용할 변수 선언
+// 3. MDEdit 컴포넌트의 prop으로 getValue 넘겨주기
+
 import MDEdit from "@/components/posts/MDEdit";
+// 1단계. useRef 임포트
+import { useRef } from "react";
 
 export default function Home() {
+  // 2단계. useRef를 사용할 변수 선언
+  const getValue = useRef("");
+
   return (
     <div className="flex flex-col h-screen">
-      {/* 고정 헤더 */}
-      <header className="h-16 bg-blue-600 text-white flex items-center justify-center shadow-md z-10">
-        <h1 className="text-xl font-bold">더미 헤더</h1>
-      </header>
-
-      {/* 스크롤 가능한 콘텐츠 영역 */}
       <main className="flex-1 overflow-y-auto bg-gray-100 p-4">
-        <MDEdit height="500"/>
+        {/* 3단계. MDEdit 컴포넌트의 prop으로 getValue 넘겨주기 */}
+        {/* height prop으로 초기 높이 설정 가능합니다. (사용자가 늘렸다 줄였다 가능) */}
+        <MDEdit height="500" getValue={getValue}/>
       </main>
+      <button onClick={() =>console.log(getValue.current)}>클릭</button>
     </div>
   );
 }

--- a/src/app/MDTest/viewer/page.js
+++ b/src/app/MDTest/viewer/page.js
@@ -1,0 +1,17 @@
+"use client"
+
+// 마크다운 뷰어 사용법
+// MDView 임포트
+// MDView 컴포넌트의 prop으로 Document를 넘겨줌
+
+import MDView from '@/components/posts/MDView';
+
+const page = () => {
+    return (
+        <div>
+            <MDView Document="# 마크다운 언어입니다."/>
+        </div>
+    );
+}
+
+export default page;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,11 +1,19 @@
+import Header from "@/components/common/Header";
 import "./globals.css";
+import Footer from "@/components/common/Footer";
+import SidebarContainer from "@/components/common/sidebar/SidebarContainer";
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <title>우리로그</title> 
       <body>
-        {children}
+        <Header/>
+        <main className="flex">
+          <SidebarContainer/>
+          <div className="flex-1">{children}</div>
+        </main>
+        <Footer/>
       </body>
     </html>
   );

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,12 +1,7 @@
-import Image from "next/image";
-import MDEdit from "../components/posts/MDEdit";
-
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-        <h1 className="text-3xl font-bold underline">
-        <MDEdit/>
-      </h1>
-    </div>
+    <>
+    홈화면입니다.
+    </>
   );
 }

--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Footer = () => {
+  return (
+    <div>Footer</div>
+  )
+}
+
+export default Footer

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Header = () => {
+  return (
+    <div>Header</div>
+  )
+}
+
+export default Header

--- a/src/components/common/sidebar/Sidebar.jsx
+++ b/src/components/common/sidebar/Sidebar.jsx
@@ -1,0 +1,68 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Home, User, Users, PenTool, Settings, BookOpen, Plus } from 'lucide-react'
+
+const sidebarItems = [
+  { title: "Home", href: "/", icon: Home },
+  { title: "MyPage", href: "/myPage", icon: User },
+  { title: "Groups", href: "/myGroup", icon: Users },
+  { title: "Create Post", href: "/posts/write", icon: PenTool },
+  { title: "My Posts", href: "/posts", icon: BookOpen },
+]
+
+const quickActions = [
+  { title: "Create Group", href: "/groups/create", icon: Plus },
+]
+
+export function Sidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="w-64 h-screen bg-white/50 backdrop-blur-sm border-r dark:bg-slate-900/50">
+      <div className="p-6">
+        {/* Main Navigation */}
+        <nav className="space-y-2">
+          {sidebarItems.map(({ title, href, icon: Icon }) => {
+            const isActive = pathname === href
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`flex items-center w-full px-4 py-2 text-sm rounded-md transition-colors
+                  ${isActive ? "bg-[#0067AC] text-white" : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-800"}`}
+              >
+                <Icon className="w-4 h-4 mr-3" />
+                {title}
+              </Link>
+            )
+          })}
+        </nav>
+
+        {/* Quick Actions */}
+        <div className="mt-8">
+          <div className="mb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            Quick Actions
+          </div>
+          <nav className="space-y-1">
+            {quickActions.map(({ title, href, icon: Icon }) => {
+              const isActive = pathname === href
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`flex items-center w-full px-3 py-2 text-sm rounded-md transition-colors
+                    ${isActive ? "bg-[#0067AC] text-white" : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-800"}`}
+                >
+                  <Icon className="w-3 h-3 mr-2" />
+                  {title}
+                </Link>
+              )
+            })}
+          </nav>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/common/sidebar/SidebarContainer.jsx
+++ b/src/components/common/sidebar/SidebarContainer.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Sidebar } from './Sidebar'
+
+const SidebarContainer = () => {
+  return (
+    <Sidebar/>
+  )
+}
+
+export default SidebarContainer

--- a/src/components/posts/MDEdit.js
+++ b/src/components/posts/MDEdit.js
@@ -2,19 +2,28 @@
 
 import React from "react";
 import MDEditor from '@uiw/react-md-editor';
+import { DropHandler } from "./MDTextarea";
 
 // prop으로 height를 받습니다.
 // 받은 값으로 초기 에디터 높이가 설정됩니다.
-export default function MDEdit({height}) {
+export default function MDEdit({height, getValue}) {
   const InitHeight = Number(height);
 
-  const [value, setValue] = React.useState("**Hello world!!!**");
+  // 에디터에 처음 입력되어 있는 문자열 세팅
+  const [value, setValue] = React.useState("여기에 작성해주세요.\n\n두 칸을 띄워야 공백이 적용됩니다. (마크다운 문법)");
+  
   return (
-    <div className="container h-max">
+    <div className="container">
       <MDEditor
         value={value}
         onChange={setValue}
         height={InitHeight}
+        textareaProps={{
+          onDrop: (e) => DropHandler(e, setValue, getValue),
+          onChange: (e) => {
+            getValue.current = e.target.value;
+          }
+        }}
       />
     </div>
   );

--- a/src/components/posts/MDEdit.js
+++ b/src/components/posts/MDEdit.js
@@ -3,15 +3,19 @@
 import React from "react";
 import MDEditor from '@uiw/react-md-editor';
 
-export default function MDEdit() {
+// prop으로 height를 받습니다.
+// 받은 값으로 초기 에디터 높이가 설정됩니다.
+export default function MDEdit({height}) {
+  const InitHeight = Number(height);
+
   const [value, setValue] = React.useState("**Hello world!!!**");
   return (
-    <div className="container">
+    <div className="container h-max">
       <MDEditor
         value={value}
         onChange={setValue}
+        height={InitHeight}
       />
-      <MDEditor.Markdown source={value} style={{ whiteSpace: 'pre-wrap' }} />
     </div>
   );
 }

--- a/src/components/posts/MDTextarea.js
+++ b/src/components/posts/MDTextarea.js
@@ -1,0 +1,22 @@
+export const DropHandler = (event, setValue, getValue) => {
+    // 현재 커서 위치, textarea에 들어있는 값 불러옴
+    const start = event.target.selectionStart;
+    const end = event.target.selectionEnd;
+    const value = event.target.value;
+
+    // 이미지 드롭 했을 때 이미지 링크가 쌩으로 추가되는 것을 금지
+    event.preventDefault();
+    event.stopPropagation();
+
+    // 마크다운 방식에 맞게 url가공
+    const url = event.dataTransfer.getData("text/plain");
+    const imgMatch = url.match(/imgurl=([^&]+)/);
+    const cleanedUrl = imgMatch ? decodeURIComponent(imgMatch[1]) : url;
+    const text = "<br>![image](" + cleanedUrl + ")<br>";
+
+    const newText = value.slice(0, start) + text + value.slice(end);
+
+    // 원래 문자열에 이미지 태그 추가 후 getRef에도 업데이트
+    setValue(newText);
+    getValue.current = newText;
+}

--- a/src/components/posts/MDView.js
+++ b/src/components/posts/MDView.js
@@ -1,0 +1,10 @@
+import MDEditor from '@uiw/react-md-editor';
+
+const MDView = ({Document}) => {
+    console.log(Document)
+    return (
+        <MDEditor.Markdown source={Document} style={{ whiteSpace: 'pre-wrap' }} />
+    );
+}
+
+export default MDView;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #2 

## 📝작업 내용

### 1. 마크다운 뷰어 기능
- 입력받은 마크다운 문서를 보기 좋게 출력합니다.

### 2. 마크다운 에디터 기능
- 마크다운 문서를 입력하면 옆쪽에 한 번에 볼 수 있습니다.
- 다른 웹페이지의 이미지를 드래그 앤 드롭할 시 해당 이미지가 문서에 복사되는 기능을 커스터마이징했습니다.
- 에디터 높이를 prop으로 쉽게 바꿀 수 있는 기능 커스터마이징했습니다.


### 스크린샷 (선택)

